### PR TITLE
Support `undefined` `max` values for quantifier nodes

### DIFF
--- a/regjsgen.js
+++ b/regjsgen.js
@@ -93,7 +93,7 @@
       return;
     }
 
-    throw Error('Invalid node type: ' + type);  
+    throw Error('Invalid node type: ' + type);
   }
 
   /*--------------------------------------------------------------------------*/
@@ -278,6 +278,7 @@
         max = node.max;
 
     switch (max) {
+      case undefined:
       case null:
         switch (min) {
           case 0:


### PR DESCRIPTION
Fixes #2.

`switch` uses `===` internally, not `==`. This wasn’t caught by the tests because they’re in JSON format, where `undefined` doesn’t exist.
