### PR TITLE
Allow dot inside alternative

### DIFF
--- a/regjsgen.js
+++ b/regjsgen.js
@@ -301,7 +301,7 @@
   }
 
   function generateTerm(node) {
-    assertType(node.type, 'anchor|characterClass|characterClassEscape|empty|group|quantifier|reference|unicodePropertyEscape|value');
+    assertType(node.type, 'anchor|characterClass|characterClassEscape|empty|group|quantifier|reference|unicodePropertyEscape|value|dot');
 
     return generate(node);
   }

--- a/tests/test-data.json
+++ b/tests/test-data.json
@@ -31411,13 +31411,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31441,13 +31451,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31471,13 +31491,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31501,13 +31531,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31531,13 +31571,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31561,13 +31611,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31591,13 +31651,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31621,13 +31691,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31651,13 +31731,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31681,13 +31771,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31711,13 +31811,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31741,13 +31851,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31771,13 +31891,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31801,13 +31931,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31831,13 +31971,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31861,13 +32011,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31891,13 +32051,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31921,13 +32091,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31951,13 +32131,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -31981,13 +32171,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32011,13 +32211,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32041,13 +32251,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32071,13 +32291,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32101,13 +32331,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32131,13 +32371,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32161,13 +32411,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32191,13 +32451,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32221,13 +32491,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32251,13 +32531,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32281,13 +32571,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32311,13 +32611,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32341,13 +32651,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32371,13 +32691,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32401,13 +32731,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32431,13 +32771,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32461,13 +32811,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32491,13 +32851,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32521,13 +32891,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32551,13 +32931,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32581,13 +32971,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32611,13 +33011,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32641,13 +33051,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32671,13 +33091,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32701,13 +33131,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32731,13 +33171,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32761,13 +33211,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32791,13 +33251,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32821,13 +33291,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32851,13 +33331,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32881,13 +33371,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32911,13 +33411,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32941,13 +33451,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -32971,13 +33491,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33001,13 +33531,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33031,13 +33571,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33061,13 +33611,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33091,13 +33651,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33121,13 +33691,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33151,13 +33731,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33181,13 +33771,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33211,13 +33811,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33241,13 +33851,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33271,13 +33891,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -33301,13 +33931,23 @@
     "body": [
       {
         "type": "value",
-        "kind": "identifier",
-        "codePoint": 99,
+        "kind": "symbol",
+        "codePoint": 92,
         "range": [
           0,
+          1
+        ],
+        "raw": "\\"
+      },
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 99,
+        "range": [
+          1,
           2
         ],
-        "raw": "\\c"
+        "raw": "c"
       },
       {
         "type": "value",
@@ -36784,5 +37424,53 @@
       8
     ],
     "raw": "(\\2)(b)a"
+  },
+  "\\a": {
+    "type": "value",
+    "kind": "identifier",
+    "codePoint": 97,
+    "range": [
+      0,
+      2
+    ],
+    "raw": "\\a"
+  },
+  "\\k": {
+    "type": "value",
+    "kind": "identifier",
+    "codePoint": 107,
+    "range": [
+      0,
+      2
+    ],
+    "raw": "\\k"
+  },
+  "a.": {
+    "type": "alternative",
+    "body": [
+      {
+        "type": "value",
+        "kind": "symbol",
+        "codePoint": 97,
+        "range": [
+          0,
+          1
+        ],
+        "raw": "a"
+      },
+      {
+        "type": "dot",
+        "range": [
+          1,
+          2
+        ],
+        "raw": "."
+      }
+    ],
+    "range": [
+      0,
+      2
+    ],
+    "raw": "a."
   }
 }


### PR DESCRIPTION
For example, in `/a./`.

Before this PR, it throws
```
Invalid node type: dot; expected types: /^(?:anchor|characterClass|characterClassEscape|empty|group|quantifier|reference|unicodePropertyEscape|value)$/
```

This affects a big number of users, because `regexpu-core` starts to emit `.` when it can: https://github.com/mathiasbynens/regexpu-core/pull/29